### PR TITLE
Fix super-h vs proguard

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -132,5 +132,6 @@
 }
 
 -keep class com.ayuget.redface.data.state.CategoriesStore { *; }
+-keep class com.ayuget.redface.image.superhost.** { *; }
 -keep class com.ayuget.redface.network.UserCookieStore { *; }
 -keep class com.ayuget.redface.network.SerializableHttpCookie { *; }

--- a/app/src/main/java/com/ayuget/redface/image/superhost/SuperHostResult.java
+++ b/app/src/main/java/com/ayuget/redface/image/superhost/SuperHostResult.java
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName;
 public class SuperHostResult {
 
     int statusCode;
-    String statusText;
+    String statusTxt;
     SuperHostImage image;
 
     public int getStatusCode() {
@@ -16,12 +16,12 @@ public class SuperHostResult {
         this.statusCode = statusCode;
     }
 
-    public String getStatusText() {
-        return statusText;
+    public String getStatusTxt() {
+        return statusTxt;
     }
 
-    public void setStatusText(String statusText) {
-        this.statusText = statusText;
+    public void setStatusTxt(String statusTxt) {
+        this.statusTxt = statusTxt;
     }
 
     public SuperHostImage getImage() {

--- a/app/src/main/java/com/ayuget/redface/image/superhost/SuperHostResultParser.java
+++ b/app/src/main/java/com/ayuget/redface/image/superhost/SuperHostResultParser.java
@@ -2,6 +2,7 @@ package com.ayuget.redface.image.superhost;
 
 import com.ayuget.redface.image.HostedImage;
 import com.ayuget.redface.image.ImageQuality;
+import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -11,7 +12,7 @@ import java.util.Map;
 public class SuperHostResultParser {
 
     HostedImage parseResult(String result) {
-        Gson gson = new GsonBuilder().serializeNulls().create();
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).serializeNulls().create();
         SuperHostResult superHostResult = gson.fromJson(result, SuperHostResult.class);
         Map<ImageQuality, String> map = new HashMap<>();
         if (superHostResult.getImage().getMedium() != null) {
@@ -20,7 +21,7 @@ public class SuperHostResultParser {
         if (superHostResult.getImage().getThumb() != null) {
             map.put(ImageQuality.THUMBNAIL, superHostResult.getImage().getThumb().getUrl());
         }
-        return HostedImage.create(superHostResult.getImage().url, map);
+        return HostedImage.create(superHostResult.getImage().getUrl(), map);
     }
 
 }

--- a/app/src/main/java/com/ayuget/redface/ui/activity/ReplyActivity.java
+++ b/app/src/main/java/com/ayuget/redface/ui/activity/ReplyActivity.java
@@ -842,7 +842,8 @@ public class ReplyActivity extends BaseActivity implements Toolbar.OnMenuItemCli
 		imageUploadObservable.subscribe(hostedImage -> {
 			Timber.d("Successfully uploaded image ! -> %s", hostedImage);
 
-			EditTextState editTextState = UiUtils.insertTextAndSaveState(replyEditText, String.format(UPLOADED_IMAGE_BB_CODE, hostedImage.url(), hostedImage.url()));
+			String mediumImageUrl = hostedImage.variant(ImageQuality.MEDIUM);
+			EditTextState editTextState = UiUtils.insertTextAndSaveState(replyEditText, String.format(UPLOADED_IMAGE_BB_CODE, hostedImage.url(), mediumImageUrl != null ? mediumImageUrl : hostedImage.url()));
 
 			// No need to restore background job anymore
 			RetainedFragmentHelper.remove(this, getSupportFragmentManager());

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -248,14 +248,14 @@
     <string name="image_enter_url_ok">OK</string>
     <string name="image_shared_success">Lien vers l\'image copié dans le presse-papier</string>
     <string name="image_shared_failure">Erreur de partage de l\'image</string>
-    <string name="upload_on_hfr_rehost">Upload sur hfrRehost</string>
-    <string name="image_sharing_confirmation">Uploader cette image sur reho.st ?</string>
+    <string name="upload_on_hfr_rehost">Upload sur Super-h</string>
+    <string name="image_sharing_confirmation">Uploader cette image sur Super-h ?</string>
     <string name="image_sharing_confirmation_negative">Non</string>
     <string name="image_sharing_confirmation_positive">Oui</string>
 
-    <string name="pref_rehost_settings">Reho.st (hébergement d\'images)</string>
+    <string name="pref_rehost_settings">Super-h (hébergement d\'images)</string>
     <string name="pref_default_uploaded_image_variant">Qualité par défaut</string>
-    <string name="pref_default_uploaded_image_variant_summary">Qualité d\'image qui sera ajoutée automatiquement aux messages une fois l\'upload sur reho.st terminé</string>
+    <string name="pref_default_uploaded_image_variant_summary">Qualité d\'image qui sera ajoutée automatiquement aux messages une fois l\'upload sur Super-h terminé</string>
     <string-array name="pref_default_uploaded_image_variant_values">
         <item>@string/image_uploaded_original</item>
         <item>@string/image_uploaded_medium</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,7 +231,7 @@
         <item>GROUP_BY_CATS</item>
     </string-array>
 
-    <string name="pref_rehost_settings">Reho.st (image service)</string>
+    <string name="pref_rehost_settings">Super-h (image service)</string>
     <string name="pref_default_uploaded_image_variant">Default quality for uploaded images</string>
     <string name="pref_default_uploaded_image_variant_summary">Choose which quality gets automatically inserted in the message right after the upload</string>
     <string name="pref_default_uploaded_image_variant_default" translatable="false">PREVIEW</string>
@@ -392,8 +392,8 @@
 
     <string name="image_shared_success">Link to image has been copied to clipboard</string>
     <string name="image_shared_failure">Failed to share image</string>
-    <string name="upload_on_hfr_rehost">Upload on hfrRehost</string>
-    <string name="image_sharing_confirmation">Upload this image to super-h?</string>
+    <string name="upload_on_hfr_rehost">Upload on Super-h</string>
+    <string name="image_sharing_confirmation">Upload this image to Super-h?</string>
     <string name="image_sharing_confirmation_positive">Yes</string>
     <string name="image_sharing_confirmation_negative">No</string>
 


### PR DESCRIPTION
exclude SuperHostResult class from proguard rules as minifying/obfuscating fields of this class results in gson deserialization error