### PR TITLE
Fix super-h rehost (ACTION_OPEN_DOCUMENT permission denial)

### DIFF
--- a/app/src/main/java/com/ayuget/redface/ui/activity/ReplyActivity.java
+++ b/app/src/main/java/com/ayuget/redface/ui/activity/ReplyActivity.java
@@ -435,6 +435,11 @@ public class ReplyActivity extends BaseActivity implements Toolbar.OnMenuItemCli
 					int resultCode = result.resultCode();
 
 					if (resultCode == RESULT_OK) {
+
+						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+							getContentResolver().takePersistableUriPermission(data.getData(), Intent.FLAG_GRANT_READ_URI_PERMISSION);
+						}
+
 						new AlertDialog.Builder(this)
 								.setPositiveButton(R.string.image_sharing_confirmation_positive, (dialog, which) -> result.targetUI().uploadImageToHostingService(data.getData()))
 								.setNegativeButton(R.string.image_sharing_confirmation_negative, (dialog, which) -> hideImageSelectionView())


### PR DESCRIPTION
Fix the following issue for image rehost (super-h)

> Permission Denial: opening provider com.android.providers.media.MediaDocumentsProvider from ProcessRecord{c636548 23208:com.ayuget.redface.debug/u0a424} (pid=23208, uid=10424) requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs [...] android.os.RemoteException: Remote stack trace:
 at com.android.server.am.ActivityManagerService.getContentProviderImpl(ActivityManagerService.java:7714)
 at com.android.server.am.ActivityManagerService.getContentProvider(ActivityManagerService.java:8246)
 at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:2462)
 at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:3138)
 at com.android.server.am.OppoActivityManagerService.onTransact(OppoActivityManagerService.java:169)