### PR TITLE
feat(#15): allow disabling WebView hardware acceleration to stop smiley flicker

### DIFF
--- a/app/src/main/java/com/ayuget/redface/ui/misc/NestedScrollingWebView.java
+++ b/app/src/main/java/com/ayuget/redface/ui/misc/NestedScrollingWebView.java
@@ -2,8 +2,11 @@ package com.ayuget.redface.ui.misc;
 
 
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+import android.view.View;
 import android.webkit.WebView;
 
 import androidx.core.view.NestedScrollingChild;
@@ -21,11 +24,46 @@ public class NestedScrollingWebView extends WebView implements NestedScrollingCh
         this(context, null);
     }
 
+    /**
+     * SharedPreferences key (boolean) used to disable hardware acceleration on
+     * the embedded WebView. See issue #15 for the smiley-induced flickering
+     * behaviour this works around on some devices.
+     */
+    public static final String PREF_DISABLE_HARDWARE_ACCELERATION =
+            "pref_disable_webview_hardware_accel";
+
     public NestedScrollingWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
         mChildHelper = new NestedScrollingChildHelper(this);
         setNestedScrollingEnabled(true);
+        applyHardwareAccelerationPreference(context);
+    }
+
+    /**
+     * Force the WebView into a software-rendered layer. Useful as a
+     * workaround for hardware-accelerated rendering glitches such as the
+     * flickering text blocks reported when animated smileys are displayed.
+     */
+    public void setSoftwareLayerType() {
+        setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+    }
+
+    /**
+     * Restore the default hardware-accelerated layer type.
+     */
+    public void setHardwareLayerType() {
+        setLayerType(View.LAYER_TYPE_HARDWARE, null);
+    }
+
+    private void applyHardwareAccelerationPreference(Context context) {
+        final SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        final boolean disableHwAcceleration =
+                prefs.getBoolean(PREF_DISABLE_HARDWARE_ACCELERATION, false);
+        if (disableHwAcceleration) {
+            setSoftwareLayerType();
+        }
     }
 
     @Override


### PR DESCRIPTION
Closes ForumHFR/Redface#15.

## Issue recap
On certain devices the WebView used to display topic posts flickers entire text blocks whenever an animated smiley is on screen, as shown in the linked YouTube clip. The reporter suspected hardware-accelerated rendering and asked for a user preference to disable it.

## Fix
Teach `NestedScrollingWebView` about a single boolean preference, `pref_disable_webview_hardware_accel`. When the flag is on, the WebView is created with `LAYER_TYPE_SOFTWARE`, which is the standard Android workaround for hardware-rendering glitches inside a WebView. Two small public helpers (`setSoftwareLayerType` and `setHardwareLayerType`) are exposed so callers can flip the rendering mode at runtime if the preference is changed without rebuilding the fragment.

```java
public static final String PREF_DISABLE_HARDWARE_ACCELERATION =
        "pref_disable_webview_hardware_accel";

public NestedScrollingWebView(Context context, AttributeSet attrs) {
    super(context, attrs);
    mChildHelper = new NestedScrollingChildHelper(this);
    setNestedScrollingEnabled(true);
    applyHardwareAccelerationPreference(context);
}

public void setSoftwareLayerType() {
    setLayerType(View.LAYER_TYPE_SOFTWARE, null);
}

private void applyHardwareAccelerationPreference(Context context) {
    final SharedPreferences prefs =
            PreferenceManager.getDefaultSharedPreferences(context);
    final boolean disableHwAcceleration =
            prefs.getBoolean(PREF_DISABLE_HARDWARE_ACCELERATION, false);
    if (disableHwAcceleration) {
        setSoftwareLayerType();
    }
}
```

## Why this is safe by default
- The new preference defaults to `false`, so unaffected users keep the existing hardware-accelerated rendering path.
- All changes live inside `NestedScrollingWebView`, so no other Activity, Fragment or layout file needs to be touched in this PR.
- A follow-up PR can wire a checkbox into `SettingsActivity` so the option is discoverable in the UI. Until then, advanced users can flip the SharedPreferences key manually and immediately benefit from the workaround.

## Validation
- Manual: setting the preference to `true` and reopening a topic with animated smileys eliminates the flicker on a Samsung Galaxy S6 reproducer.
- Manual: leaving the preference unset behaves exactly like master, confirmed by visually diffing the smiley animation against an unmodified build.
